### PR TITLE
Add allow attribute to iframe to allow clipboard access

### DIFF
--- a/src/DrawIoEmbed.tsx
+++ b/src/DrawIoEmbed.tsx
@@ -171,6 +171,7 @@ export const DrawIoEmbed = forwardRef<DrawIoEmbedRef, DrawIoEmbedProps>(
         className="diagrams-iframe"
         src={iframeUrl}
         ref={iframeRef}
+        allow="clipboard-read; clipboard-write"
         title="Diagrams.net"
         style={{
           width: '100%',


### PR DESCRIPTION
This PR adds the `allow` attribute to the iframe to allow clipboard access. That allows right click->copy to copy directly to the clipboard.